### PR TITLE
chore: execute message after receive an event

### DIFF
--- a/src/clients/AxelarClient.ts
+++ b/src/clients/AxelarClient.ts
@@ -2,7 +2,7 @@ import { CosmosNetworkConfig } from '../config/types';
 import { StdFee } from '@cosmjs/stargate';
 import {
   getConfirmGatewayTxPayload,
-  getExecuteGeneralMessageWithTokenPayload,
+  getExecuteMessageRequest,
   getSignCommandPayload,
 } from '../utils/payloadBuilder';
 import { sleep } from '../utils/utils';
@@ -97,12 +97,12 @@ export class AxelarClient {
     return `0x${response.executeData}`;
   }
 
-  public async executeGeneralMessageWithToken(
+  public async executeMessageRequest(
     logIndex: number,
     txHash: string,
     payload: string
   ) {
-    const _payload = getExecuteGeneralMessageWithTokenPayload(
+    const _payload = getExecuteMessageRequest(
       this.signingClient.getAddress(),
       txHash,
       logIndex,
@@ -110,7 +110,7 @@ export class AxelarClient {
     );
     return this.signingClient.broadcast(_payload).catch((e: any) => {
       logger.error(
-        `[AxelarClient.executeGeneralMessageWithToken] Failed to broadcast ${e.message}`
+        `[AxelarClient.executeMessageRequest] Failed to broadcast ${e.message}`
       );
     });
   }

--- a/src/handler/eventHandler.ts
+++ b/src/handler/eventHandler.ts
@@ -58,7 +58,7 @@ export async function handleEvmToCosmosEvent(
   // Sent an execute tx to testnet
   // Check if the tx is already executed
 
-  const executeTx = await vxClient.executeGeneralMessageWithToken(
+  const executeTx = await vxClient.executeMessageRequest(
     event.logIndex,
     event.hash,
     event.args.payload
@@ -146,6 +146,19 @@ async function relayTxToEvmGateway<
 
   // If no evm client found, return
   if (!evmClient) return;
+
+  // TODO: Remove this when it's live on testnet
+  if (env.CHAIN_ENV === 'devnet') {
+    const executeMessage = await vxClient.executeMessageRequest(
+      -1,
+      event.args.messageId,
+      event.args.payload
+    );
+
+    logger.info(
+      `[handleCosmosToEvmEvent] Executed: ${executeMessage.transactionHash}`
+    );
+  }
 
   const pendingCommands = await vxClient.getPendingCommands(
     event.args.destinationChain

--- a/src/utils/payloadBuilder.ts
+++ b/src/utils/payloadBuilder.ts
@@ -44,7 +44,7 @@ export function getConfirmGatewayTxPayload(
   ];
 }
 
-export function getExecuteGeneralMessageWithTokenPayload(
+export function getExecuteMessageRequest(
   sender: string,
   txHash: string,
   logIndex: number,
@@ -56,7 +56,7 @@ export function getExecuteGeneralMessageWithTokenPayload(
       value: ExecuteMessageRequest.fromPartial({
         sender: toAccAddress(sender),
         payload: fromHex(payload.slice(2)),
-        id: `${txHash}-${logIndex}`,
+        id: logIndex === -1 ? `${txHash}` : `${txHash}-${logIndex}`,
       }),
     },
   ];


### PR DESCRIPTION
# Changes

- Send `ExecuteMessageRequest` after receiving `CallContractSubmitted` or `CallContractWithTokenSubmitted` event. (only for devnet)