### PR TITLE
chore: rename execute message type

### DIFF
--- a/src/clients/AxelarClient.ts
+++ b/src/clients/AxelarClient.ts
@@ -2,7 +2,7 @@ import { CosmosNetworkConfig } from '../config/types';
 import { StdFee } from '@cosmjs/stargate';
 import {
   getConfirmGatewayTxPayload,
-  getExecuteMessageRequest,
+  getRouteMessageRequest,
   getSignCommandPayload,
 } from '../utils/payloadBuilder';
 import { sleep } from '../utils/utils';
@@ -106,7 +106,7 @@ export class AxelarClient {
     txHash: string,
     payload: string
   ) {
-    const _payload = getExecuteMessageRequest(
+    const _payload = getRouteMessageRequest(
       this.signingClient.getAddress(),
       txHash,
       logIndex,

--- a/src/handler/eventHandler.ts
+++ b/src/handler/eventHandler.ts
@@ -167,18 +167,15 @@ async function relayTxToEvmGateway<
   // If no evm client found, return
   if (!evmClient) return;
 
-  // TODO: Remove this when it's live on testnet
-  if (env.CHAIN_ENV === 'devnet') {
-    const executeMessage = await vxClient.executeMessageRequest(
-      -1,
-      event.args.messageId,
-      event.args.payload
-    );
+  const executeMessage = await vxClient.executeMessageRequest(
+    -1,
+    event.args.messageId,
+    event.args.payload
+  );
 
-    logger.info(
-      `[handleCosmosToEvmEvent] Executed: ${executeMessage.transactionHash}`
-    );
-  }
+  logger.info(
+    `[handleCosmosToEvmEvent] Executed: ${executeMessage.transactionHash}`
+  );
 
   const pendingCommands = await vxClient.getPendingCommands(
     event.args.destinationChain

--- a/src/utils/payloadBuilder.ts
+++ b/src/utils/payloadBuilder.ts
@@ -44,7 +44,7 @@ export function getConfirmGatewayTxPayload(
   ];
 }
 
-export function getExecuteMessageRequest(
+export function getRouteMessageRequest(
   sender: string,
   txHash: string,
   logIndex: number,
@@ -52,7 +52,7 @@ export function getExecuteMessageRequest(
 ) {
   return [
     {
-      typeUrl: `/${AxelarProtobufPackage}.ExecuteMessageRequest`,
+      typeUrl: `/${AxelarProtobufPackage}.RouteMessageRequest`,
       value: ExecuteMessageRequest.fromPartial({
         sender: toAccAddress(sender),
         payload: fromHex(payload.slice(2)),


### PR DESCRIPTION
- Updated tx type from `ExecuteMessageRequest` to `RouteMessageRequest`
- Remove check to send execute message for both testnet and devnet, instead of only devnet
