### PR TITLE
feat: support `CallContractSubmitted` event from axelar

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,8 +24,8 @@ export interface IBCPacketEvent {
 
 export interface IBCEvent<T> {
   hash: string;
-  srcChannel: string;
-  destChannel: string;
+  srcChannel?: string;
+  destChannel?: string;
   args: T;
 }
 

--- a/src/utils/parseUtils.ts
+++ b/src/utils/parseUtils.ts
@@ -49,8 +49,8 @@ export const parseContractCallSubmittedEvent = (
 
   return {
     hash: event['tx.hash'][0],
-    srcChannel: event['write_acknowledgement.packet_src_channel'][0],
-    destChannel: event['write_acknowledgement.packet_dst_channel'][0],
+    srcChannel: event?.['write_acknowledgement.packet_src_channel']?.[0],
+    destChannel: event?.['write_acknowledgement.packet_dst_channel']?.[0],
     args: data,
   };
 };
@@ -76,8 +76,8 @@ export const parseContractCallWithTokenSubmittedEvent = (
 
   return {
     hash: event['tx.hash'][0],
-    srcChannel: event['write_acknowledgement.packet_src_channel'][0],
-    destChannel: event['write_acknowledgement.packet_dst_channel'][0],
+    srcChannel: event?.['write_acknowledgement.packet_src_channel']?.[0],
+    destChannel: event?.['write_acknowledgement.packet_dst_channel']?.[0],
     args: data,
   };
 };


### PR DESCRIPTION
# Description

This PR adds support for `CallContractRequest` transaction submission on the `Axelar Network`. The main difference between receiving a CallContractSubmitted event on the `Axelar Network` and on Cosmos-based chains is that the srcChannel and destChannel values will be undefined, since an incoming IBC transfer is not required.