### PR TITLE
chore: cleanup folder structure and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,16 @@ Make sure docker engine is running. We use docker for spin up local postgres db.
 1. Copy `.env.example` to `.env` and fill all values.
 2. Run `yarn`
 3. Run `make up` to run postgres db container.
-4. Run `make prisma-push` to create database and tables.
-5. Wait until the db is ready to accept connection, then run `yarn start:dev` to start the relayer.
+4. Wait until the db is ready to accept connection, then run `make prisma-push` to create database and tables.
+5. Run `prisma-generate` to generate db types.
+6. Run `yarn start:dev` to start the relayer
 
 ## API
 
 The relayer has stored the cross-chain events in the database. It exposes an API for developers for the debugging purpose.
 
-The API documentation in available [here](https://evm-cosmos-relayer.herokuapp.com/documentation).
+The API documentation in available [here](https://evm-cosmos-relayer-testnet.herokuapp.com/documentation).
 
 ## Examples
 
-### Cosmos to Evm
-
-Make sure you have set `EVM_PRIVATE_KEY` in `.env` and have at least 1 `USDA` and some native balance.
-
-```
-yarn cosmos-gmp
-```
-
-### Evm to Cosmos
-
-1. `yarn` to install dependency
-2. `yarn task multisend your_axelar_account amount` e.g. `yarn task multisend axelar199km5vjuu6edyjlwx62wvmr6uqeghyz4rwmyvk 10000`
+Work in progress

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "scripts": {
     "lint": "eslint .",
     "build": "rm -rf dist && tsc",
-    "start:dev": "nodemon --watch 'src/**/*.ts' --exec NODE_ENV=development ts-node src/relay.ts",
-    "start:prod": "NODE_ENV=production node dist/src/relay.js",
-    "start": "node dist/src/relay.js",
+    "start:dev": "nodemon --watch 'src/**/*.ts' --exec NODE_ENV=development ts-node src/start.ts",
+    "start:prod": "NODE_ENV=production node dist/src/start.js",
     "test": "jest",
     "postinstall": "typechain --target ethers-v5 --out-dir src/types/contracts/ src/abi/*.json"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist && tsc",
     "start:dev": "nodemon --watch 'src/**/*.ts' --exec NODE_ENV=development ts-node src/start.ts",
     "start:prod": "NODE_ENV=production node dist/src/start.js",
-    "start": "NODE_ENV=production node dist/src/start.js",
+    "start": "node dist/src/start.js",
     "test": "jest",
     "postinstall": "typechain --target ethers-v5 --out-dir src/types/contracts/ src/abi/*.json"
   },

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "evm-cosmos-relayer",
   "version": "1.0.0",
   "description": "",
-  "main": "dist/src/relay.js",
+  "main": "dist/src/start.js",
   "scripts": {
     "lint": "eslint .",
     "build": "rm -rf dist && tsc",
     "start:dev": "nodemon --watch 'src/**/*.ts' --exec NODE_ENV=development ts-node src/start.ts",
     "start:prod": "NODE_ENV=production node dist/src/start.js",
+    "start": "NODE_ENV=production node dist/src/start.js",
     "test": "jest",
     "postinstall": "typechain --target ethers-v5 --out-dir src/types/contracts/ src/abi/*.json"
   },

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,7 @@ import Inert from '@hapi/inert';
 import Vision from '@hapi/vision';
 import HapiSwagger from 'hapi-swagger';
 
-export const initServer = async () => {
+export const startAPIServer = async () => {
   const prisma = new PrismaClient();
   const server = hapi.server({
     port: env.PORT,

--- a/src/clients/AxelarClient/index.ts
+++ b/src/clients/AxelarClient/index.ts
@@ -5,7 +5,7 @@ import {
   getConfirmGatewayTxPayload,
   getRouteMessageRequest,
   getSignCommandPayload,
-} from '../../utils/payloadBuilder';
+} from './payloadBuilder';
 import { sleep } from '../../clients/sleep';
 import { sha256 } from 'ethers/lib/utils';
 import { DatabaseClient } from 'clients';

--- a/src/clients/AxelarClient/payloadBuilder.ts
+++ b/src/clients/AxelarClient/payloadBuilder.ts
@@ -4,20 +4,12 @@ import {
   SignCommandsRequest as EvmSignCommandsRequest,
 } from '@axelar-network/axelarjs-types/axelar/evm/v1beta1/tx';
 import {
-  MsgTransfer,
-  protobufPackage,
-} from '@axelar-network/axelarjs-types/ibc/applications/transfer/v1/tx';
-import { Height } from 'cosmjs-types/ibc/core/client/v1/client';
-import {
   ExecuteMessageRequest,
   protobufPackage as AxelarProtobufPackage,
 } from '@axelar-network/axelarjs-types/axelar/axelarnet/v1beta1/tx';
 import { toAccAddress } from '@cosmjs/stargate/build/queryclient/utils';
 import { fromHex } from '@cosmjs/encoding';
 import { utils } from 'ethers';
-import { Coin } from '@cosmjs/stargate';
-import Long from 'long';
-// import { logger } from '../logger';
 
 /**
  * Get payload for confirm gateway tx on evm chain
@@ -68,47 +60,3 @@ export function getSignCommandPayload(sender: string, chain: string) {
     },
   ];
 }
-
-export function getMsgIBCTransfer(
-  senderAddress: string,
-  sourceChannel: string,
-  amount: string,
-  memo: Uint8Array
-) {
-  const axelarModuleAccount = 'axelar19xj4ncc6h6y5ahpfqtspdx75y3dkrxj3zpah9k';
-  const sourcePort = 'transfer';
-  const timeoutHeight: Height = {
-    revisionHeight: Long.fromNumber(100),
-    revisionNumber: Long.fromNumber(100),
-  };
-  const sendToken: Coin = {
-    amount,
-    denom: 'ibc/52E89E856228AD91E1ADE256E9EDEA4F2E147A426E14F71BE7737EB43CA2FCC5',
-  };
-
-  return [
-    {
-      typeUrl: `/${protobufPackage}.MsgTransfer`,
-      value: MsgTransfer.fromPartial({
-        sourcePort,
-        sourceChannel,
-        sender: senderAddress,
-        receiver: axelarModuleAccount,
-        token: sendToken,
-        timeoutHeight,
-        memo: Buffer.from(memo).toString('hex'),
-      }),
-    },
-  ];
-}
-
-// function get(
-//   senderAddress: string,
-//   signer: SigningStargateClient
-// ) {
-//     const fee = {
-//       gas: "100000",
-//       amount: [{ denom: "uvx", amount: "30000" }]
-//     }
-//     return signer.sign(senderAddress, [transferMsg], fee, "");
-//   }

--- a/src/listeners/EvmListener/parser.ts
+++ b/src/listeners/EvmListener/parser.ts
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers';
-import { filterEventArgs } from '../../utils/operatorUtils';
 import { TypedEvent } from '../../types/contracts/common';
 
 export const parseAnyEvent = async (
@@ -24,4 +23,13 @@ export const parseAnyEvent = async (
     },
     args: filterEventArgs(event),
   };
+};
+
+
+const filterEventArgs = (event: TypedEvent) => {
+  return Object.entries(event.args).reduce((acc, [key, value]) => {
+    if (!isNaN(Number(key))) return acc;
+    acc[key] = value;
+    return acc;
+  }, {} as any);
 };

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -1,0 +1,1 @@
+export * from "./relay";

--- a/src/relayer/rxOperators.ts
+++ b/src/relayer/rxOperators.ts
@@ -10,14 +10,6 @@ import {
 import { CosmosNetworkConfig } from '../config/types';
 import { EvmClient } from '../clients';
 
-export const filterEventArgs = (event: TypedEvent) => {
-  return Object.entries(event.args).reduce((acc, [key, value]) => {
-    if (!isNaN(Number(key))) return acc;
-    acc[key] = value;
-    return acc;
-  }, {} as any);
-};
-
 export function filterCosmosDestination(cosmosChains: CosmosNetworkConfig[]) {
   return filter(
     (

--- a/src/relayer/subject.ts
+++ b/src/relayer/subject.ts
@@ -1,5 +1,5 @@
 import { Subject } from 'rxjs';
-import { EvmEvent, IBCEvent } from './types';
+import { EvmEvent, IBCEvent } from '../types';
 
 export function createEvmEventSubject<T>(): Subject<EvmEvent<T>> {
   return new Subject<EvmEvent<T>>();

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,6 +1,6 @@
-import { logger } from "logger";
-import { startAPIServer } from "api";
-import { startRelayer } from "relayer";
+import { logger } from "./logger";
+import { startAPIServer } from "./api";
+import { startRelayer } from "./relayer";
 
 logger.info('Starting relayer api server...');
 startAPIServer();

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,7 @@
+import { logger } from "logger";
+import { startAPIServer } from "api";
+import { startRelayer } from "relayer";
+
+logger.info('Starting relayer api server...');
+startAPIServer();
+startRelayer();


### PR DESCRIPTION
# Description

This PR removed example section in `README.md` as it isn't working anymore. Also, grouping the imported files that used by `relay.ts` into the same folder.