### PR TITLE
fix: ws connection drop

### DIFF
--- a/src/listeners/AxelarListener/AxelarListener.ts
+++ b/src/listeners/AxelarListener/AxelarListener.ts
@@ -1,4 +1,4 @@
-import ReconnectingWebSocket from 'reconnecting-websocket';
+import ReconnectingWebSocket, { CloseEvent } from 'reconnecting-websocket';
 import WebSocket from 'isomorphic-ws';
 import { Subject } from 'rxjs';
 import { AxelarListenerEvent } from './eventTypes';
@@ -8,8 +8,8 @@ export class AxelarListener {
   private wsMap: Map<string, ReconnectingWebSocket>;
   private wsOptions = {
     WebSocket, // custom WebSocket constructor
-    connectionTimeout: 30000,
-    maxRetries: 10,
+    connectionTimeout: 5000,
+    maxRetries: Infinity,
   };
 
   private wsUrl: string;
@@ -33,7 +33,7 @@ export class AxelarListener {
   public listen<T>(event: AxelarListenerEvent<T>, subject: Subject<T>) {
     const ws = this.getWs(event.topicId);
     ws.reconnect();
-    logger.info(`[AxelarListener] Listening to "${event.type}" event`);
+    logger.info(`[AxelarLisatener] Listening to "${event.type}" event`);
     ws.send(
       JSON.stringify({
         jsonrpc: '2.0',

--- a/src/listeners/AxelarListener/AxelarListener.ts
+++ b/src/listeners/AxelarListener/AxelarListener.ts
@@ -1,4 +1,4 @@
-import ReconnectingWebSocket, { CloseEvent } from 'reconnecting-websocket';
+import ReconnectingWebSocket from 'reconnecting-websocket';
 import WebSocket from 'isomorphic-ws';
 import { Subject } from 'rxjs';
 import { AxelarListenerEvent } from './eventTypes';
@@ -8,7 +8,6 @@ export class AxelarListener {
   private wsMap: Map<string, ReconnectingWebSocket>;
   private wsOptions = {
     WebSocket, // custom WebSocket constructor
-    connectionTimeout: 5000,
     maxRetries: Infinity,
   };
 
@@ -19,7 +18,7 @@ export class AxelarListener {
     this.wsUrl = wsUrl;
   }
 
-  private getWs(topicId: string) {
+  private initWs(topicId: string) {
     const _ws = this.wsMap.get(topicId);
     if (_ws) {
       return _ws;
@@ -31,17 +30,24 @@ export class AxelarListener {
   }
 
   public listen<T>(event: AxelarListenerEvent<T>, subject: Subject<T>) {
-    const ws = this.getWs(event.topicId);
-    ws.reconnect();
-    logger.info(`[AxelarLisatener] Listening to "${event.type}" event`);
-    ws.send(
-      JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'subscribe',
-        params: [event.topicId],
-      })
-    );
+    const ws = this.initWs(event.topicId);
+    ws.addEventListener('open', () => {
+      ws.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'subscribe',
+          params: [event.topicId],
+        })
+      );
+      logger.info(`[AxelarListener] Listening to "${event.type}" event`);
+    });
+
+    ws.addEventListener('close', () => {
+      logger.debug(`[AxelarListener] ws connection for ${event.type} is closed. Reconnect Ws...`);
+      ws.reconnect();
+    });
+
     ws.addEventListener('message', (ev: MessageEvent<any>) => {
       // convert buffer to json
       const _event = JSON.parse(ev.data.toString());


### PR DESCRIPTION
This PR resolves ws connection drop by detecting close event and automatically call `reconnect()` to reconnect websocket.